### PR TITLE
GigHub URLを編集

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -18,9 +18,8 @@ export const About:React.FC =()=>{
 		<br /><br />
 
 		■GitHub<br />
-		ソースコード<br />
-		https://github.com/t-kyohsuke/Portfolio<br />
-		<br />
+		<a href="https://github.com/t-kyohsuke/Portfolio" target="_blank" rel="noopener noreferrer">ソースコード</a>
+		<br /><br />
 		作成：多田享補
 	</>);
 }


### PR DESCRIPTION
GitHubのURLのリンクを有効にして、新しいタブで開くようにした。